### PR TITLE
Select Dropdown doesn't update position when moving window

### DIFF
--- a/cmd/demo/main.go
+++ b/cmd/demo/main.go
@@ -15,6 +15,8 @@ func main() {
 	defer w.Destroy()
 	w.SetTitle("Minimal webview example")
 	w.SetSize(800, 600, webview2.HintFixed)
-	w.Navigate("https://en.m.wikipedia.org/wiki/Main_Page")
+	//w.Navigate("https://en.m.wikipedia.org/wiki/Main_Page")
+	//Change website url for now so we have a page with a html select element we can test
+	w.Navigate("https://www.w3schools.com/tags/tryit.asp?filename=tryhtml_select")
 	w.Run()
 }

--- a/cmd/demo/main.go
+++ b/cmd/demo/main.go
@@ -15,8 +15,6 @@ func main() {
 	defer w.Destroy()
 	w.SetTitle("Minimal webview example")
 	w.SetSize(800, 600, webview2.HintFixed)
-	//w.Navigate("https://en.m.wikipedia.org/wiki/Main_Page")
-	//Change website url for now so we have a page with a html select element we can test
-	w.Navigate("https://www.w3schools.com/tags/tryit.asp?filename=tryhtml_select")
+	w.Navigate("https://en.m.wikipedia.org/wiki/Main_Page")
 	w.Run()
 }

--- a/internal/w32/w32.go
+++ b/internal/w32/w32.go
@@ -1,10 +1,11 @@
 package w32
 
 import (
-	"golang.org/x/sys/windows"
 	"syscall"
 	"unicode/utf16"
 	"unsafe"
+
+	"golang.org/x/sys/windows"
 )
 
 var (
@@ -58,10 +59,13 @@ const (
 
 const (
 	WMDestroy       = 0x0002
+	WMMove          = 0x0003
 	WMSize          = 0x0005
 	WMClose         = 0x0010
 	WMQuit          = 0x0012
 	WMGetMinMaxInfo = 0x0024
+	WMNCLButtonDown = 0x00A1
+	WMMoving        = 0x0216
 	WMApp           = 0x8000
 )
 

--- a/internal/w32/w32.go
+++ b/internal/w32/w32.go
@@ -1,11 +1,10 @@
 package w32
 
 import (
+	"golang.org/x/sys/windows"
 	"syscall"
 	"unicode/utf16"
 	"unsafe"
-
-	"golang.org/x/sys/windows"
 )
 
 var (

--- a/pkg/edge/ICoreWebView2Controller.go
+++ b/pkg/edge/ICoreWebView2Controller.go
@@ -106,3 +106,14 @@ func (i *ICoreWebView2Controller) GetICoreWebView2Controller2() *ICoreWebView2Co
 
 	return result
 }
+
+func (i *ICoreWebView2Controller) NotifyParentWindowPositionChanged() error {
+	var err error
+	_, _, err = i.vtbl.NotifyParentWindowPositionChanged.Call(
+		uintptr(unsafe.Pointer(i)),
+	)
+	if err != windows.ERROR_SUCCESS {
+		return err
+	}
+	return nil
+}

--- a/pkg/edge/chromium.go
+++ b/pkg/edge/chromium.go
@@ -315,3 +315,12 @@ func (e *Chromium) NavigationCompleted(sender *ICoreWebView2, args *ICoreWebView
 	}
 	return 0
 }
+
+func (e *Chromium) NotifyParentWindowPositionChanged() error {
+	//It looks like the wndproc function is called before the controller initialization is complete.
+	//Because of this the controller is nil
+	if e.controller == nil {
+		return nil
+	}
+	return e.controller.NotifyParentWindowPositionChanged()
+}

--- a/webview.go
+++ b/webview.go
@@ -6,13 +6,14 @@ package webview2
 import (
 	"encoding/json"
 	"errors"
-	"github.com/leaanthony/go-webview2/internal/w32"
-	"github.com/leaanthony/go-webview2/pkg/edge"
 	"log"
 	"reflect"
 	"strconv"
 	"sync"
 	"unsafe"
+
+	"github.com/leaanthony/go-webview2/internal/w32"
+	"github.com/leaanthony/go-webview2/pkg/edge"
 
 	"golang.org/x/sys/windows"
 )
@@ -40,6 +41,7 @@ type browser interface {
 	Navigate(url string)
 	Init(script string)
 	Eval(script string)
+	NotifyParentWindowPositionChanged() error
 }
 
 type webview struct {
@@ -168,6 +170,12 @@ func (w *webview) callbinding(d rpcMessage) (interface{}, error) {
 func wndproc(hwnd, msg, wp, lp uintptr) uintptr {
 	if w, ok := getWindowContext(hwnd).(*webview); ok {
 		switch msg {
+		case w32.WMMove, w32.WMMoving:
+			w.browser.NotifyParentWindowPositionChanged()
+		case w32.WMNCLButtonDown:
+			w32.User32SetFocus.Call(w.hwnd)
+			r, _, _ := w32.User32DefWindowProcW.Call(hwnd, msg, wp, lp)
+			return r
 		case w32.WMSize:
 			w.browser.Resize()
 		case w32.WMClose:

--- a/webview.go
+++ b/webview.go
@@ -6,14 +6,13 @@ package webview2
 import (
 	"encoding/json"
 	"errors"
+	"github.com/leaanthony/go-webview2/internal/w32"
+	"github.com/leaanthony/go-webview2/pkg/edge"
 	"log"
 	"reflect"
 	"strconv"
 	"sync"
 	"unsafe"
-
-	"github.com/leaanthony/go-webview2/internal/w32"
-	"github.com/leaanthony/go-webview2/pkg/edge"
 
 	"golang.org/x/sys/windows"
 )


### PR DESCRIPTION
See: https://github.com/wailsapp/wails/issues/1081

Exposed the `NotifyParentWindowPositionChanged()` function on the chromium struct.

Updated `webview.go` to call this function on the `w32.WMMove` and `w32.WMMoving` message. Also added calling the `w32.User32SetFocus.Call(w.hwnd)` function on the `w32.WMNCLButtonDown` message so the select dropdown will close when we click outside of the webview (e.g. the menu bar). 

We still call `w32.User32DefWindowProcW.Call(hwnd, msg, wp, lp)` afterwards because otherwise the button down event will not be handled by the window (e.g. cannot close window when clicking on the close button).