### PR TITLE
Update chromium_386.go

### DIFF
--- a/pkg/edge/chromium_386.go
+++ b/pkg/edge/chromium_386.go
@@ -5,6 +5,7 @@ package edge
 
 import (
 	"unsafe"
+	"github.com/leaanthony/go-webview2/internal/w32"
 )
 
 func (e *Chromium) Resize() {


### PR DESCRIPTION
 undefined: w32
fix win32 compilation